### PR TITLE
Modify Assistant - Take existing id from the state instead of the plan

### DIFF
--- a/openai/assistant_resource.go
+++ b/openai/assistant_resource.go
@@ -241,7 +241,7 @@ func (r *AssistantResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	tflog.Info(ctx, fmt.Sprintf("Updating Assistant: %s", data.Id.ValueString()))
+	tflog.Info(ctx, fmt.Sprintf("Updating Assistant: %s", state.Id.ValueString()))
 
 	aReq := openai.AssistantRequest{
 		Model:        data.Model.ValueString(),

--- a/openai/assistant_resource.go
+++ b/openai/assistant_resource.go
@@ -241,7 +241,7 @@ func (r *AssistantResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	tflog.Info(ctx, "Updating Assistant: %s", state.Id.ValueString())
+	tflog.Info(ctx, fmt.Sprintf("Updating Assistant: %s", data.Id.ValueString()))
 
 	aReq := openai.AssistantRequest{
 		Model:        data.Model.ValueString(),


### PR DESCRIPTION
I made a mistake in the last PR. I took the ID from the plan instead of the state.  Hopefully, now it will fix the issue that it keeps creating new Assistants instead of updating them.